### PR TITLE
fix: FUM-74 image and text on mobile to fit screen and spacing on form

### DIFF
--- a/src/components/page/JoinNow.svelte
+++ b/src/components/page/JoinNow.svelte
@@ -125,7 +125,7 @@
       background-size: cover;
       background-position: top right;
       background-repeat: no-repeat;
-      min-height: 100vh;
+      height: 100svh;
       width: 55%;
 
       display: flex;
@@ -146,9 +146,7 @@
       flex-direction: column;
       justify-content: center;
       align-items: end;
-      @media (max-width: 375px) {
-        padding-top: 341px;
-      }
+
       @media (max-width: 800px) {
         font-size: 32px;
         padding-right: 40px;
@@ -164,6 +162,9 @@
       &--message {
         @media (max-width: 800px) {
           font-size: 32px;
+          position: absolute;
+          bottom: 1.5rem;
+          right: 1.5rem;
         }
 
         font-size: 64px;
@@ -231,7 +232,7 @@
         margin-left: 0;
         width: 100%;
         border-radius: 0;
-        padding: 120px 40px;
+        padding: 1rem;
       }
 
       &--container {
@@ -242,7 +243,8 @@
       }
 
       &--heading {
-        margin-bottom: 8px;
+        margin-bottom: 1rem;
+        padding-top: 1rem;
 
         font-size: calc(30px + 1vw);
       }
@@ -300,6 +302,10 @@
       position: fixed;
       z-index: 20;
     }
+    @media (max-width: 375px) {
+      top: 8px;
+      left: 8px;
+    }
 
     &--icon {
       width: 20px;
@@ -333,12 +339,12 @@
     flex-direction: row;
     align-items: center;
     color: #00a900;
-    margin-bottom: 1.75rem;
+    margin-bottom: 1rem;
     font-size: 1.25rem;
   }
 
   .info-block {
-    margin-bottom: 1.75rem;
+    margin-bottom: 1rem;
     &__heading {
       font-size: 1.125rem;
       font-family: $heading;

--- a/src/components/page/JoinNow.svelte
+++ b/src/components/page/JoinNow.svelte
@@ -57,7 +57,7 @@
       <h2 class="impact__form--heading">Join Future Super</h2>
       <div class="time-row">
         <img src="/images/clock2.gif" alt="clock" class="clock" />
-        <h4>Takes about 4 minutes.</h4>
+        <h4>It only takes 5 minutes</h4>
       </div>
       <div class="info-block">
         <p class="info-block__heading">What you'll need</p>
@@ -188,8 +188,8 @@
       }
 
       &--text {
+        display: none;
         padding-top: 10%;
-        display: flex;
         justify-content: end;
         text-align: center;
         width: 100%;


### PR DESCRIPTION
updated it so the image and text on mobile will fit to the users screen height, including the toolbars that are included with ios and android - adjusted the spacing on the form